### PR TITLE
Create go-debug-metrics-exposure.yaml

### DIFF
--- a/http/exposures/apis/go-debug-metrics-exposure.yaml
+++ b/http/exposures/apis/go-debug-metrics-exposure.yaml
@@ -1,0 +1,44 @@
+id: go-debug-metrics-exposure
+
+info:
+  name: Go Debug Endpoint Exposure (expvar / metrics / pprof)
+  author: Alvin Bijo (@OffgridOps)
+  severity: medium
+  description: |
+    Detects exposed debug endpoints such as /debug/vars, /metrics, or /debug/pprof 
+    which are commonly used in Go services and may leak sensitive internal data like 
+    environment variables, memory stats, or command-line args.
+
+  reference:
+    - https://pkg.go.dev/expvar
+    - https://prometheus.io/docs/instrumenting/exporters/
+    - https://github.com/OffgridOps
+  tags: exposure,debug,metrics,go,expvar,prometheus,devops
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/debug/vars"
+      - "{{BaseURL}}/metrics"
+      - "{{BaseURL}}/debug/pprof/"
+
+    matchers-condition: or
+    matchers:
+      - type: word
+        part: body
+        words:
+          - "\"cmdline\""
+          - "\"memstats\""
+        condition: and
+
+      - type: regex
+        part: body
+        regex:
+          - "API_KEY=.*"
+          - "DB_PASS=.*"
+
+      - type: word
+        part: body
+        words:
+          - "# HELP"
+          - "# TYPE"


### PR DESCRIPTION
Added a custom Nuclei template to detect exposed Go debug endpoints like /debug/vars, /metrics, and /debug/pprof that may leak sensitive internal information such as API keys, memory stats, and environment variables.

Author: Alvin Bijo (@OffgridOps)

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->

- Fixed CVE-2020-XXX / Added CVE-2020-XXX / Updated CVE-2020-XXX
- References:

### Template Validation

I've validated this template locally?
- [x] YES
- [ ] NO


#### Additional Details (leave it blank if not applicable)

<!-- Include Shodan / Fofa / Google Query / Docker / Screenshots if available -->
<!-- Include HTTP/TCP/DNS Matched response data snippet if available -->
<!-- Please do NOT include vulnerable host information in pull requests -->
<!-- None of the prerequisites are obligatory; they are merely intended to speed the review process. -->

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)